### PR TITLE
Add WHERE

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ This approach allows for efficient calculation of total records even in large ta
 
    Replace `<table_name>` with the name of the table you want to count.
 
+
+5. (Optional) Set the `WHERE` environment variable to specify additional conditions for the SQL query. The value should be a valid SQL condition. For example, to count only the records where the `name` column contains 'Alice', you would set the `WHERE` environment variable like this:
+
+   ```
+   export WHERE="AND name LIKE '%Alice%'"
+   ```
+
+Note: The `WHERE` environment variable is appended directly to the SQL query, so it should start with 'AND' or 'OR' followed by a space. Be careful to write a valid SQL condition.
+
 ## Notes
 
 - This utility works only with tables where the `id` column is a numeric primary key.

--- a/main_test.go
+++ b/main_test.go
@@ -110,7 +110,7 @@ func TestGetTotalCountParallel(t *testing.T) {
 
 	step := 2
 	expectedTotalCount := 3
-	totalCount, err := getTotalCountParallel(db, "users", 3, step, 2)
+	totalCount, err := getTotalCountParallel(db, "users", 3, step, "", 2)
 	if err != nil {
 		t.Fatalf("getTotalCount failed: %v", err)
 	}


### PR DESCRIPTION
```shell
%CONCURRENCY=5 STEP_SIZE=100000 DATABASE_URL="root: your_pass@tcp(127.0.0.1:3306)/table_count_test" go run main.go users
2024/03/09 14:37:28 Total number of records in the users table: 100000000
2024/03/09 14:37:28 Total running time: 4.39842275s
```


```shell
%WHERE="AND name LIKE '%1%'" CONCURRENCY=5 STEP_SIZE=100000 DATABASE_URL="root:root@tcp(127.0.0.1:3306)/table_count_test" go run main.go users
2024/03/09 14:38:40 Total number of records in the users table: 56953280
2024/03/09 14:38:40 Total running time: 7.092402792s
```

```sql
SELECT COUNT(id) FROM users WHERE name LIKE '%1%' -- 23s
```

